### PR TITLE
Refactored player monitors

### DIFF
--- a/Configs/Editor/AttributeLists/Edit.conf
+++ b/Configs/Editor/AttributeLists/Edit.conf
@@ -2,6 +2,14 @@ SCR_EditorAttributeList {
  m_aAttributes {
   SCR_WeatherInstantEditorAttribute "{565074C6A6320210}" {
   }
+  DisableGMBudget_BudgetsEnabledAttribute "{65D6CC58785869E0}" {
+   m_UIInfo SCR_EditorAttributeUIInfo "{65D6CC587F71D9A4}" {
+    Name "Use Budget"
+    Description "Should the Game Maseter use a budget"
+   }
+   m_CategoryConfig "{EDD16BBBE3767070}Configs/Editor/AttributeCategories/GameSettings.conf"
+   m_Layout "{D0F3CE0C63A5AEBB}UI/layouts/Editor/Attributes/AttributePrefabs/AttributePrefab_Checkbox.layout"
+  }
   TW_FactionSelectorAttribute "{626AF7DA618E4B22}" {
    m_UIInfo SCR_EditorAttributeUIInfo "{626AF7DA64C40B53}" {
     Name "Select Faction"

--- a/Scripts/Game/Attributes/TW_DisableGMBudgetAttribute.c
+++ b/Scripts/Game/Attributes/TW_DisableGMBudgetAttribute.c
@@ -1,11 +1,26 @@
-modded class SCR_BudgetEditorComponent 
-{
-	const int DEFAULT_MAX_BUDGET = int.MAX;
-	override bool IsBudgetCapEnabled() { return false; }	
-};
-
-modded class SCR_EntityBudgetValue
-{
-	override int GetBudgetValue() { return int.MAX; }
-	override void SetBudgetValue(int newValue) { m_Value = int.MAX; }
+[BaseContainerProps(), SCR_BaseEditorAttributeCustomTitle()]
+class DisableGMBudget_BudgetsEnabledAttribute : SCR_BaseEditorAttribute
+{	
+	override SCR_BaseEditorAttributeVar ReadVariable(Managed item, SCR_AttributesManagerEditorComponent manager)
+	{
+		//If opened in global attributes
+		
+		SCR_BaseGameMode gamemode = SCR_BaseGameMode.Cast(item);
+		if (!gamemode)
+			return null;
+		
+		return SCR_BaseEditorAttributeVar.CreateBool(gamemode.DisableGMBudget_AreBudgetsEnabled());
+	}
+	
+	override void WriteVariable(Managed item, SCR_BaseEditorAttributeVar var, SCR_AttributesManagerEditorComponent manager, int playerID)
+	{
+		if (!var) 
+			return;
+		
+		SCR_BaseGameMode gamemode = SCR_BaseGameMode.Cast(item);
+		if (!gamemode)
+			return;
+		
+		gamemode.DisableGMBudget_SetBudgetsEnabled(var.GetBool());
+	}
 };

--- a/Scripts/Game/Entities/TW_AISpawnPoint.c
+++ b/Scripts/Game/Entities/TW_AISpawnPoint.c
@@ -70,7 +70,15 @@ class TW_AISpawnPoint : GenericEntity
 	
 	static void GetSpawnPointsInChunks(notnull set<string> playerChunks, notnull set<string> antiSpawnChunks, notnull array<TW_AISpawnPoint> spawnPoints)
 	{
-		int antiRadius = TW_MonitorPositions.GetInstance().GetAntiSpawnGridSizeInMeters();
+		if(!TW_MonitorPositions.GetInstance().HasGridSystem(s_GridManager.GetGridSize()))
+		{
+			PrintFormat("TrainWreck: Unable to get spawn points in chunks. Grid System for GridSize: '%1' does not exist", s_GridManager.GetGridSize(), LogLevel.WARNING);
+			return;	
+		}
+		
+		ref TW_Grid gridSystem = TW_MonitorPositions.GetInstance().GetGridSystem(s_GridManager.GetGridSize());
+		
+		int antiRadius = gridSystem.GetAntiGridRadius();
 		
 		int x, y;
 		ref array<TW_AISpawnPoint> points = {};

--- a/Scripts/Game/Systems/TW_MonitorPositions.c
+++ b/Scripts/Game/Systems/TW_MonitorPositions.c
@@ -1,3 +1,63 @@
+class TW_Grid
+{
+	private int m_GridSize;
+	private int m_GridRadius;
+	private int m_AntiGridRadius;
+	
+	private ref set<string> m_PlayerChunks;
+	private ref set<string> m_AntiChunks;
+	
+	void TW_Grid(int gridSize, int gridRadius, int antiRadius=-1)
+	{
+		m_GridSize = gridSize;
+		m_GridRadius = gridRadius;
+		
+		if(antiRadius > 0)
+			m_AntiGridRadius = antiRadius;
+		
+		m_PlayerChunks = new set<string>();
+		m_AntiChunks = new set<string>();
+	}
+	
+	int GetGridSize() { return m_GridSize; }
+	int GetGridRadius() { return m_GridRadius; }
+	int GetAntiGridRadius() { return m_AntiGridRadius; }
+	
+	void SetAntiRadius(int radius) { m_AntiGridRadius = radius; }
+	void SetGridRadius(int radius) { m_GridRadius = radius; }
+	
+	set<string> GetPlayerChunks() { return m_PlayerChunks; }
+	set<string> GetAntiChunks() { return m_AntiChunks; }
+	
+	bool HasChunk(string chunk) { return m_PlayerChunks.Contains(chunk); }
+	bool HasAntiChunk(string chunk) { return m_AntiChunks.Contains(chunk); }
+	
+	void AddChunk(string chunk) { m_PlayerChunks.Insert(chunk); }
+	void AddAntiChunk(string chunk) { m_AntiChunks.Insert(chunk); }
+	
+	void SetPlayerChunks(set<string> chunks)
+	{
+		m_PlayerChunks.Clear();
+		m_PlayerChunks.Copy(chunks);
+	}
+	
+	void SetAntiChunks(notnull set<string> chunks)
+	{
+		m_AntiChunks.Clear();
+		m_AntiChunks.Copy(chunks);
+	}
+	
+	string GetPosition(IEntity player)
+	{
+		return TW_Util.ToGridText(player.GetOrigin(), GetGridSize());
+	}
+	
+	string GetPosition(vector position)
+	{
+		return TW_Util.ToGridText(position, GetGridSize());
+	}
+};
+
 class GridUpdateEvent
 {
 	private ref set<string> m_PlayerChunks;
@@ -16,6 +76,14 @@ class GridUpdateEvent
 	set<string> GetUnloadedChunks() { return m_UnloadedChunks; }
 };
 
+void TW_OnPlayerPositionsChanged(GridUpdateEvent gridInfo);
+typedef func TW_OnPlayerPositionsChangedDelegate;
+typedef ScriptInvoker<ref TW_OnPlayerPositionsChangedDelegate> TW_OnPlayerPositionsChangedInvoker;
+
+void TW_OnGridSystemChanged(int oldGridSize, int newGridSize, TW_Grid newGrid);
+typedef func TW_OnGridSystemChangedDelegate;
+typedef ScriptInvoker<ref TW_OnGridSystemChangedDelegate> TW_OnGridSystemChangedInvoker;
+
 class TW_MonitorPositions
 {
 	private static TW_MonitorPositions s_Instance;
@@ -25,48 +93,149 @@ class TW_MonitorPositions
 		return s_Instance;
 	}
 	
-	private ref set<string> m_PlayerChunks = new set<string>();
-	private ref set<string> m_AntiSpawnChunks = new set<string>();
-	
+	private ref map<int, ref TW_Grid> m_GridSystems = new map<int, ref TW_Grid>();
+		
 	private ref array<IEntity> m_Players = {};
-	private int m_PlayerChunkCount = 0;
 	
-	private int m_GridSize;
-	private int m_GridRadius;
-	private int m_AntiSpawnGridSize;
-	private int m_AntiSpawnDistanceInChunks;
+	private ref map<int, ref TW_OnPlayerPositionsChangedInvoker> m_OnGridUpdate = new map<int, ref TW_OnPlayerPositionsChangedInvoker>();
 	
-	private ref ScriptInvoker<ref GridUpdateEvent> m_OnGridUpdate = new ScriptInvoker<ref GridUpdateResponse>();
+	private ref TW_OnGridSystemChangedInvoker m_OnGridSystemChanged = new TW_OnGridSystemChangedInvoker();
 	
-	ScriptInvoker<ref GridUpdateEvent> GetGridUpdate() { return m_OnGridUpdate; }
+	TW_OnGridSystemChangedInvoker GetOnGridSystemChanged() { return m_OnGridSystemChanged; }
 	
-	int GetGridSizeInMeters() { return m_GridSize; }
-	int GetDistanceInChunks() { return m_GridRadius; }
-	int GetAntiSpawnGridSizeInMeters() { return m_AntiSpawnGridSize; }
-	int GetAntiSpawnDistanceInChunks() { return m_AntiSpawnDistanceInChunks; }
+	TW_OnPlayerPositionsChangedInvoker GetGridUpdate(int gridSize) 
+	{ 
+		if(!HasGridSystem(gridSize)) 
+			return null;
+		
+		if(!m_OnGridUpdate.Contains(gridSize))
+			return null;
+		
+		return m_OnGridUpdate.Get(gridSize);
+	}
 	
-	void TW_MonitorPositions(int gridSize, int gridRadius, int antiGridSize, int antiRadius)
+	//! Does the monitor have a system for specific grid size
+	bool HasGridSystem(int size) { return m_GridSystems.Contains(size); }
+	
+	//! Retrieve grid system by size (if it exists)
+	TW_Grid GetGridSystem(int size)
 	{
-		UpdateGrid(gridSize, gridRadius, antiGridSize, antiRadius);
+		if(!HasGridSystem(size)) return null;
+		return m_GridSystems.Get(size);
+	}
+	
+	//! Swap an existing grid with new grid, keyed by size
+	void ReplaceGridSystem(int oldSize, int newSize, notnull TW_Grid grid)
+	{
+		if(HasGridSystem(oldSize))
+		{
+			m_GridSystems.Remove(oldSize);
+		}
+		
+		RemoveGridInvoker(oldSize);
+		
+		m_GridSystems.Insert(newSize, grid);
+		if(GetOnGridSystemChanged())
+			GetOnGridSystemChanged().Invoke(oldSize, newSize, grid);
+	}
+	
+	//! Remove subscriptions to grid size
+	private void RemoveGridInvoker(int oldSize)
+	{
+		if(m_OnGridUpdate.Contains(oldSize))
+		{
+			ref TW_OnPlayerPositionsChangedInvoker invoker = m_OnGridUpdate.Get(oldSize);
+			invoker.Clear();
+			delete invoker;
+			
+			m_OnGridUpdate.Remove(oldSize);
+		}	
+	}
+	
+	//! Remove Grid System, and any listeners
+	void RemoveGridSystem(int gridSize)
+	{
+		if(HasGridSystem(gridSize))
+		{
+			m_GridSystems.Remove(gridSize);
+		}
+		
+		RemoveGridInvoker(gridSize);
+	}
+	
+	void TW_MonitorPositions()
+	{
 		s_Instance = this;
 	}
 	
 	void ~TW_MonitorPositions()
 	{
+		m_GridSystems.Clear();
+		
+		foreach(int size, TW_OnPlayerPositionsChangedInvoker invoker : m_OnGridUpdate)
+			invoker.Clear();
+		
 		m_OnGridUpdate.Clear();
 	}
 	
-	//! Update grid dimensions at runtime
-	void UpdateGrid(int gridSize, int gridRadius, int antiGridSize, int antiRadius)
+	void AddGridSystem(int gridSize, int gridRadius, int antiRadius)
 	{
-		m_GridSize = gridSize;
-		m_GridRadius = gridRadius;
-		m_AntiSpawnGridSize = antiGridSize;
-		m_AntiSpawnDistanceInChunks = antiRadius;
+		if(HasGridSystem(gridSize))
+		{
+			ref TW_Grid grid = GetGridSystem(gridSize);
+			
+			if(grid.GetGridRadius() != gridRadius)
+			{
+				PrintFormat("TrainWreck: Grid Size '%1' already existed. Existing radius of '%2' is being updated to '%3'", gridSize, grid.GetGridRadius(), gridRadius, LogLevel.WARNING);
+			}
+			
+			if(grid.GetAntiGridRadius() != antiRadius)
+			{
+				PrintFormat("TrainWreck: Grid Size '%1' already existed. Existing anti radius of '%2' is being updated to '%3'", gridSize, grid.GetAntiGridRadius(), antiRadius, LogLevel.WARNING);
+			}
+			
+			grid.SetGridRadius(gridRadius);
+			grid.SetAntiRadius(antiRadius);
+			return;
+		}
 		
-		m_PlayerChunks.Clear();
-		m_PlayerChunkCount = 0;
-		m_AntiSpawnChunks.Clear();
+		ref TW_Grid grid = new TW_Grid(gridSize, gridRadius, antiRadius);
+		m_GridSystems.Insert(gridSize, grid);
+		m_OnGridUpdate.Insert(gridSize, new TW_OnPlayerPositionsChangedInvoker());
+	}
+	
+	void AddSpawnGridSystem(int gridSize, int gridRadius)
+	{
+		if(HasGridSystem(gridSize))
+		{
+			ref TW_Grid grid = GetGridSystem(gridSize);
+			
+			if(grid.GetGridRadius() != gridRadius)
+			{
+				PrintFormat("TrainWreck: Grid Size '%1' already existed. Existing radius of '%2' is being updated to '%3'", gridSize, grid.GetGridRadius(), gridRadius, LogLevel.WARNING);
+			}
+			
+			grid.SetGridRadius(gridRadius);
+			
+			return;
+		}
+		
+		ref TW_Grid grid = new TW_Grid(gridSize, gridRadius);
+		m_GridSystems.Insert(gridSize, grid);
+		m_OnGridUpdate.Insert(gridSize, new TW_OnPlayerPositionsChangedInvoker());
+	}
+	
+	void AddAntiGridSystem(int gridSize, int gridRadius)
+	{
+		if(HasGridSystem(gridSize))
+		{
+			GetGridSystem(gridSize).SetAntiRadius(gridRadius);
+			return;
+		}
+		
+		ref TW_Grid grid = new TW_Grid(gridSize, -1, gridRadius);
+		m_GridSystems.Insert(gridSize, grid);
+		m_OnGridUpdate.Insert(gridSize, new TW_OnPlayerPositionsChangedInvoker());
 	}
 	
 	void MonitorPlayers()
@@ -81,62 +250,82 @@ class TW_MonitorPositions
 		
 		bool positionsHaveChanged = false;
 		
-		m_AntiSpawnChunks.Clear();
-		
 		ref set<string> chunksAroundPlayer = new set<string>();
+		ref set<string> antiSpawnChunks = new set<string>();
 		
-		// Where are players currently located
 		foreach(int playerId : playerIds)
 		{
 			auto player = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerId);
-			
-			if(!player)
-				continue;
-			
-			chunksAroundPlayer.Clear();
-			
-			TW_Util.AddSurroundingGridSquares(m_AntiSpawnChunks, player.GetOrigin(), m_AntiSpawnDistanceInChunks, m_AntiSpawnGridSize);
-			TW_Util.AddSurroundingGridSquares(chunksAroundPlayer, player.GetOrigin(), m_GridRadius, m_GridSize);
-			
-			foreach(string chunk : chunksAroundPlayer)
-			{
-				if(!m_PlayerChunks.Contains(chunk))
-				{
-					positionsHaveChanged = true;
-					m_PlayerChunks.Insert(chunk);
-				}
-				
-				if(!currentPositions.Contains(chunk))
-					currentPositions.Insert(chunk);
-			}
-			
+			if(!player) continue;
 			players.Insert(player);
 		}
 		
-		m_PlayerChunkCount = m_PlayerChunks.Count();
+		m_Players.Clear();
+		m_Players.Copy(players);
 		
-		// are previous chunks still valid?
-		for(int i = 0; i < m_PlayerChunkCount; i++)
+		foreach(int gridSize, ref TW_Grid gridSystem : m_GridSystems)
 		{
-			string playerCoord = m_PlayerChunks.Get(i);
+			positionsHaveChanged = false;
+			antiSpawnChunks.Clear();
+			chunksAroundPlayer.Clear();
+			unloaded.Clear();
+			currentPositions.Clear();
 			
-			if(!currentPositions.Contains(playerCoord))
+			foreach(IEntity player : players)
 			{
-				unloaded.Insert(playerCoord);
-				m_PlayerChunks.Remove(i);
+				chunksAroundPlayer.Clear();
 				
-				// Must remember to decrement otherwise we skip an item
-				i -= 1;
-				m_PlayerChunkCount -= 1;
+				if(gridSystem.GetAntiGridRadius() > 0)
+				{
+					TW_Util.AddSurroundingGridSquares(antiSpawnChunks, player.GetOrigin(), gridSystem.GetAntiGridRadius(), gridSystem.GetGridSize());
+					gridSystem.SetAntiChunks(antiSpawnChunks);
+				}
 				
-				positionsHaveChanged = true;
+				if(gridSystem.GetGridRadius() > 0)
+				{
+					TW_Util.AddSurroundingGridSquares(chunksAroundPlayer, player.GetOrigin(), gridSystem.GetGridRadius(), gridSystem.GetGridSize());
+					
+					foreach(string chunk : chunksAroundPlayer)
+					{
+						if(!gridSystem.HasChunk(chunk))
+						{
+							positionsHaveChanged = true;
+							gridSystem.AddChunk(chunk);
+						}
+						
+						if(!currentPositions.Contains(chunk))
+							currentPositions.Insert(chunk);
+					}
+				}
 			}
-		}
-		
-		if(positionsHaveChanged)
-		{
-			ref GridUpdateEvent updateEvent = new GridUpdateEvent(m_PlayerChunks, m_AntiSpawnChunks, unloaded);
-			m_OnGridUpdate.Invoke(updateEvent);
+			
+			if(gridSystem.GetGridRadius() > 0)
+			{
+				int chunkCount = gridSystem.GetPlayerChunks().Count();
+				
+				for(int i = 0; i < chunkCount; i++)
+				{
+					string playerCoord = gridSystem.GetPlayerChunks().Get(i);
+					
+					if(!currentPositions.Contains(playerCoord))
+					{
+						unloaded.Insert(playerCoord);
+						gridSystem.GetPlayerChunks().Remove(i);
+						i -= 1;
+						chunkCount -= 1;
+						positionsHaveChanged = true;
+					}
+				}
+			}
+			
+			if(positionsHaveChanged)
+			{
+				if(!m_OnGridUpdate.Contains(gridSystem.GetGridSize()))
+					continue;
+				
+				ref GridUpdateEvent updateEvent = new GridUpdateEvent(gridSystem.GetPlayerChunks(), gridSystem.GetAntiChunks(), unloaded);
+				m_OnGridUpdate.Get(gridSystem.GetGridSize()).Invoke(updateEvent);
+			}
 		}
 	}
 };

--- a/Scripts/Game/Systems/TW_SettingsManager.c
+++ b/Scripts/Game/Systems/TW_SettingsManager.c
@@ -1,0 +1,30 @@
+class TW_SettingsInterface<Class T>
+{
+	protected static bool isInitialized;
+	static bool IsInitialized() { return isInitialized; }
+	
+	void Initialize(T settings);
+	void SaveSettings();
+	void ResetToDefault();
+};
+
+class TW_SettingsManager<TW_SettingsInterface TInterface>
+{
+	protected ref TInterface _interface;
+	
+	TInterface GetInterface() { return _interface; }
+	
+	void TW_SettingsManager()
+	{
+		_interface = new TInterface();
+		PrintFormat("TrainWreck: Settings manager for %1 initialized", GetInterface().Type());
+	}
+	
+	private static ref TW_SettingsManager<TInterface> _instance;
+	static TW_SettingsManager<TInterface> GetInstance()
+	{
+		if(_instance) return _instance;
+		_instance = new TW_SettingsManager<TInterface>();
+		return _instance;
+	}
+};

--- a/Scripts/Game/TW_Util.c
+++ b/Scripts/Game/TW_Util.c
@@ -1,3 +1,70 @@
+class TW_IterableHelper<Class T>
+{
+	//! Get common items between both iterable arrays
+	static int GetIntersection(notnull array<T> one, notnull array<T> two, inout array<T> common)
+	{
+		int count = 0;
+		
+		foreach(ref T item : one)
+		{
+			if(!two.Contains(item))
+				continue;
+			
+			common.Insert(item);
+			count++;
+		}
+		
+		return count;
+	}
+	
+	//! Get common items between both iterable sets
+	static int GetIntersection(notnull set<T> one, notnull set<T> two, inout set<T> common)
+	{
+		int count = 0;
+		foreach(ref T item : one)
+		{
+			if(!two.contains(item))
+				continue;
+			
+			common.Insert(item);
+			count++;
+		}
+		
+		return count;
+	}
+	
+	static int GetDifference(notnull array<T> one, notnull array<T> two, inout array<T> diff)
+	{
+		int count = 0;
+		foreach(ref T item : one)
+		{
+			if(two.Contains(item))
+				continue;
+			
+			diff.Insert(item);
+			count++;
+		}
+		
+		return count;
+	}
+	
+	static int GetDifference(notnull set<T> one, notnull set<T> two, inout set<T> diff)
+	{
+		int count = 0;
+		
+		foreach(ref T item : one)
+		{
+			if(two.Contains(item))
+				continue;
+			
+			diff.Insert(item);
+			count++;
+		}
+		
+		return count;
+	}
+};
+
 class TW_Util 
 {
 	static ref RandomGenerator s_Generator = new RandomGenerator();

--- a/Scripts/Game/TW_Util.c
+++ b/Scripts/Game/TW_Util.c
@@ -527,6 +527,11 @@ class TW_Util
 		if(s_VehicleSizes.Contains(prefab))
 			return s_VehicleSizes.Get(prefab);
 		
+		if(!GetGame().InPlayMode())
+		{
+			return vector.Zero;
+		}
+		
 		if(!world)
 			world = GetGame().GetWorld();
 		

--- a/Scripts/Game/modded/modded_SCR_BaseGameMode.c
+++ b/Scripts/Game/modded/modded_SCR_BaseGameMode.c
@@ -12,6 +12,9 @@ modded class SCR_BaseGameMode
 	protected ref ScriptInvoker Event_OnGamePluginsInitialized = new ScriptInvoker();
 	protected ref ScriptInvoker Event_OnGameStarted = new ScriptInvoker();
 	
+	[RplProp(onRplName: "DisableGMBudget_OnBroadcastValueUpdated")]
+	bool m_TWBudgetsEnabled = false;
+	
 	protected void InitializePlugins();	
 	
 	override void StartGameMode()
@@ -46,6 +49,8 @@ modded class SCR_BaseGameMode
 			GetOnGameStarted().Invoke();
 				
 		Print("TrainWreck: GameMode Starting...");
+		
+		DisableGMBudget_SetBudgetsEnabled(m_TWBudgetsEnabled);
 
 		m_fTimeElapsed = 0.0;
 		m_eGameState = SCR_EGameModeState.GAME;
@@ -111,6 +116,25 @@ modded class SCR_BaseGameMode
 		
 		ref TW_MapLocation location = m_MapManager.GetRandomLocation();
 		ref LocationConfig config = m_MapManager.settings.GetConfigType(location.LocationType());
+	}
+	
+	void DisableGMBudget_SetBudgetsEnabled(bool enabled)
+	{
+		m_TWBudgetsEnabled = enabled;
+		SCR_BudgetEditorComponent.SetIsBudgetEnabled(enabled);
+		
+		Replication.BumpMe();
+		DisableGMBudget_OnBroadcastValueUpdated();
+	}
+	
+	bool DisableGMBudget_AreBudgetsEnabled() 
+	{
+		return m_TWBudgetsEnabled;
+	};
+	
+	private void DisableGMBudget_OnBroadcastValueUpdated()
+	{
+		SCR_BudgetEditorComponent.SetIsBudgetEnabled(m_TWBudgetsEnabled);
 	}
 	
 }

--- a/Scripts/Game/modded/modded_SCR_BaseGameMode.c
+++ b/Scripts/Game/modded/modded_SCR_BaseGameMode.c
@@ -4,7 +4,7 @@
 modded class SCR_BaseGameMode 
 {
 	protected ref TW_MonitorPositions positionMonitor;
-	protected float m_PositionMonitorUpdateInterval = 10.0;
+	protected float m_PositionMonitorUpdateInterval = 5.0;
 	
 	protected ref TW_MapManager m_MapManager;
 	
@@ -13,7 +13,7 @@ modded class SCR_BaseGameMode
 	protected ref ScriptInvoker Event_OnGameStarted = new ScriptInvoker();
 	
 	[RplProp(onRplName: "DisableGMBudget_OnBroadcastValueUpdated")]
-	bool m_TWBudgetsEnabled = false;
+	bool m_TWBudgetsEnabled = true;
 	
 	protected void InitializePlugins();	
 	
@@ -96,6 +96,14 @@ modded class SCR_BaseGameMode
 	{
 		if(positionMonitor)
 			positionMonitor.MonitorPlayers();
+	}
+	
+	//! Change how often player positions are checked
+	void ChangeMonitorInterval(float seconds)
+	{
+		m_PositionMonitorUpdateInterval = seconds;
+		GetGame().GetCallqueue().Remove(MonitorUpdate);
+		GetGame().GetCallqueue().CallLater(MonitorUpdate, m_PositionMonitorUpdateInterval * 1000, true);
 	}
 	
 	override void EOnInit(IEntity owner) 

--- a/Scripts/Game/modded/modded_SCR_BudgetEditorComponent.c
+++ b/Scripts/Game/modded/modded_SCR_BudgetEditorComponent.c
@@ -1,0 +1,11 @@
+modded class SCR_BudgetEditorComponent 
+{
+	private static bool TW_IsBudgetEnabled = true;
+	static bool GetIsBudgetEnabled() { return TW_IsBudgetEnabled; }
+	static void SetIsBudgetEnabled(bool value) { TW_IsBudgetEnabled = value; }
+	
+	override bool IsBudgetCapEnabled() 
+	{ 
+		return TW_IsBudgetEnabled; 
+	}
+};

--- a/Scripts/Game/modded/modded_SCR_EntityBudgetValue.c
+++ b/Scripts/Game/modded/modded_SCR_EntityBudgetValue.c
@@ -1,0 +1,11 @@
+[BaseContainerProps(), SCR_BaseContainerCustomTitleEnum(EEditableEntityBudget, "m_BudgetType")]
+modded class SCR_EntityBudgetValue
+{
+	override int GetBudgetValue() 
+	{
+		if(SCR_BudgetEditorComponent.GetIsBudgetEnabled()) 
+			return m_Value;
+		
+		return int.MAX; 
+	}
+};


### PR DESCRIPTION
As the ecosystem grew, a few things happened.

Identified the "Anti Spawn" logic didn't work as intended. Whenever a different grid size was needed, I had a custom monitor. Now the player position monitor supports multiple "Grid Systems"

Each grid system tracks the radius, and anti-radius along with player chunks/anti chunks. Whenever player positions are scanned, we iterate over each grid system that's being tracked - updating things along the way.

# Breaking Changes
Consumers now have to subscribe to a grid size. The signature is the same, GridUpdateEvent, but they must subscribe to a specific grid size in order to receive updates based on that grid.
