### PR TITLE
Fix for duplicate spawn points

### DIFF
--- a/Scripts/Game/Grid/TW_GridCoordArrayManager.c
+++ b/Scripts/Game/Grid/TW_GridCoordArrayManager.c
@@ -118,7 +118,7 @@ class TW_GridCoordArrayManager<Class T>
 	}
 	
 	//! Retrieve coords around center
-	int GetNeighbors(notnull out array<ref TW_GridCoordArray<T>> items, int x, int y, int radius = 1, bool includeCenter = true)
+	int GetNeighbors(notnull out array<ref TW_GridCoordArray<T>> items, int x, int y, inout set<string> processed, int radius = 1, bool includeCenter = true)
 	{
 		radius = Math.Max(0, radius);
 		
@@ -134,6 +134,11 @@ class TW_GridCoordArrayManager<Class T>
 			{
 				if(gridX == x && gridY == y && !includeCenter)
 					continue;
+				
+				string coord = TW_Util.ToGridText(gridX, gridY);
+				if(processed.Contains(coord))
+					continue;
+				processed.Insert(coord);
 				
 				if(HasCoord(gridX, gridY))
 				{
@@ -165,7 +170,7 @@ class TW_GridCoordArrayManager<Class T>
 	}
 	
 	//! Get all chunks around player positions
-	int GetChunksAround(notnull out array<ref TW_GridCoordArray<T>> chunks, notnull set<string> textCoords, int radius = 1)
+	int GetChunksAround(notnull out array<ref TW_GridCoordArray<T>> chunks, notnull set<string> textCoords)
 	{
 		ref set<string> completedCoords = new set<string>();
 		
@@ -197,25 +202,22 @@ class TW_GridCoordArrayManager<Class T>
 		return totalCount;
 	}
 	
-	int GetNeighborsAround(notnull out array<T> data, notnull set<string> textCoords, int radius = 0)
+	int GetNeighborsAround(notnull out array<T> data, notnull set<string> textCoords, inout set<string> processed, int radius = 0)
 	{
-		ref set<string> completedCoords = new set<string>();
-		
 		int x;
 		int y;
 		int totalCount = 0;
 		
 		foreach(string textCoord : textCoords)
 		{
-			if(completedCoords.Contains(textCoord))
+			if(processed.Contains(textCoord))
 				continue;
 			
 			TW_Util.FromGridString(textCoord, x, y);
 			
-			
 			if(radius <= 0)
 			{
-				completedCoords.Insert(textCoord);
+				processed.Insert(textCoord);
 					
 				if(HasCoord(x, y))
 				{
@@ -235,8 +237,10 @@ class TW_GridCoordArrayManager<Class T>
 					for(int cy = bottom; cy < top; cy++)
 					{
 						string coord = string.Format("%1 %2", cx, cy);
-						if(completedCoords.Contains(coord))
+						if(processed.Contains(coord))
 							continue;
+						
+						processed.Insert(coord);
 						
 						if(HasCoord(x, y))
 						{
@@ -252,10 +256,10 @@ class TW_GridCoordArrayManager<Class T>
 		return totalCount;
 	}	
 	
-	int GetNeighboringItems(notnull out array<T> items, int x, int y, int radius = 1, bool includeCenter = true)
+	int GetNeighboringItems(notnull out array<T> items, int x, int y, inout set<string> processed, int radius = 1, bool includeCenter = true)
 	{
 		ref array<ref TW_GridCoordArray<T>> neighbors = {};
-		int chunks = GetNeighbors(neighbors, x, y, radius, includeCenter);
+		int chunks = GetNeighbors(neighbors, x, y, processed, radius, includeCenter);
 		
 		if(chunks < 0)
 			return 0;

--- a/Scripts/Game/Systems/SpawnSystem.c
+++ b/Scripts/Game/Systems/SpawnSystem.c
@@ -39,9 +39,10 @@ class TW_AISpawnPointGrid
 	*/
 	void GetSpawnPointsInChunks(notnull set<string> chunks, notnull array<TW_AISpawnPoint> spawnPoints, int radius = -1)
 	{
+		ref set<string> processed = new set<string>();
 		foreach(string chunk : chunks)
 		{
-			m_Grid.GetNeighborsAround(spawnPoints, chunks, radius);
+			m_Grid.GetNeighborsAround(spawnPoints, chunks, processed, radius);
 		}
 	}
 	
@@ -58,11 +59,22 @@ class TW_AISpawnPointGrid
 		if(!m_Grid.HasCoord(x, y))
 			return;
 		
+		ref set<string> processed = new set<string>();
+		
+		processed.Insert(TW_Util.ToGridText(center, m_GridSize));
+		
 		ref array<ref TW_GridCoordArray<TW_AISpawnPoint>> items = {};
-		m_Grid.GetNeighbors(items, x, y, radius);
+		m_Grid.GetNeighbors(items, x, y, processed, radius);
 		
 		foreach(ref TW_GridCoordArray<TW_AISpawnPoint> item : items)
 		{
+			string currentCoord = TW_Util.ToGridText(item.x, item.y);
+			
+			if(processed.Contains(currentCoord))
+				continue;
+			
+			processed.Insert(currentCoord);
+			
 			ref array<TW_AISpawnPoint> points = item.GetAll();
 			foreach(TW_AISpawnPoint spawnPoint : points)
 			{
@@ -117,9 +129,10 @@ class TW_VehicleSpawnPointGrid
 	*/
 	void GetSpawnPointsInChunks(notnull set<string> chunks, notnull array<TW_VehicleSpawnPoint> spawnPoints, int radius = -1)
 	{
+		ref set<string> processed = new set<string>();
 		foreach(string chunk : chunks)
 		{
-			m_Grid.GetNeighborsAround(spawnPoints, chunks, radius);
+			m_Grid.GetNeighborsAround(spawnPoints, chunks, processed, radius);
 		}
 	}
 	
@@ -136,8 +149,10 @@ class TW_VehicleSpawnPointGrid
 		if(!m_Grid.HasCoord(x, y))
 			return;
 		
+		ref set<string> processed = new set<string>();
+		
 		ref array<ref TW_GridCoordArray<TW_VehicleSpawnPoint>> items = {};
-		m_Grid.GetNeighbors(items, x, y, radius);
+		m_Grid.GetNeighbors(items, x, y, processed, radius);
 		
 		foreach(ref TW_GridCoordArray<TW_VehicleSpawnPoint> item : items)
 		{

--- a/Scripts/Game/Systems/TW_MonitorPositions.c
+++ b/Scripts/Game/Systems/TW_MonitorPositions.c
@@ -1,3 +1,4 @@
+// Delegates for making it easier to work with later
 void TW_OnPlayerPositionsChanged(GridUpdateEvent gridInfo);
 typedef func TW_OnPlayerPositionsChangedDelegate;
 typedef ScriptInvoker<ref TW_OnPlayerPositionsChangedDelegate> TW_OnPlayerPositionsChangedInvoker;

--- a/Scripts/Game/TW_Util.c
+++ b/Scripts/Game/TW_Util.c
@@ -491,6 +491,11 @@ class TW_Util
 		return string.Format("%1 %2", x, y);
 	}
 	
+	static string ToGridText(int x, int y)
+	{
+		return string.Format("%1 %2", x, y);
+	}
+	
 	//! Convert World Position to grid-based coordinates
 	static void ToGrid(vector position, out int x, out int y, int gridSize = 1000)
 	{


### PR DESCRIPTION
Fixes #8 

- We weren't skipping/ignoring grids that were already collected. Now it's memoized, and we pass around the processed chunks to ensure recursion doesn't process the same chunk.

Everon has like 15k spawn points. Before the fix it would return 120k spawn points near the northern airport. With the fix we get around 2k-3k depending on where.  